### PR TITLE
Load web-fonts asynchronously.

### DIFF
--- a/src/shared/styles/imports/variables.css
+++ b/src/shared/styles/imports/variables.css
@@ -21,7 +21,9 @@
    ========================================================================== */
 
 :root {
+    --typography-display-font-fallback: "Helvetica Neue", Helvetica, Arial, sans-serif;
     --typography-display-font: "Rubik", sans-serif;
+    --typography-text-font-fallback: "Helvetica Neue", Helvetica, Arial, sans-serif;
     --typography-text-font: "Rubik", sans-serif;
 }
 

--- a/src/shared/styles/typography.css
+++ b/src/shared/styles/typography.css
@@ -13,9 +13,13 @@ body {
 
 body {
     color: var(--color-white);
-    font-family: var(--typography-text-font);
+    font-family: var(--typography-text-font-fallback);
     font-size: 16px;
     overflow-wrap: break-word;  /* Break long words by default */
+}
+
+.wf-active body {
+    font-family: var(--typography-text-font);
 }
 
 ::selection {
@@ -51,10 +55,19 @@ h3,
 h4,
 h5,
 h6 {
-    font-family: var(--typography-display-font);
+    font-family: var(--typography-display-font-fallback);
     font-weight: 400;
     text-transform: uppercase;
     line-height: 1.1;
+}
+
+.wf-active h1,
+.wf-active h2,
+.wf-active h3,
+.wf-active h4,
+.wf-active h5,
+.wf-active h6 {
+    font-family: var(--typography-display-font);
 }
 
 h1 {

--- a/web/.index.html.js
+++ b/web/.index.html.js
@@ -27,7 +27,9 @@ export default function index({ head, rootHtml, config, buildManifest }) {
                 ${head.link.toString()}
 
                 <!-- Rubik from Google-->
-                <link href="https://fonts.googleapis.com/css?family=Rubik:300,400,500,700" rel="stylesheet">
+                <link href="//ajax.googleapis.com" rel="dns-prefetch">
+                <link href="//fonts.googleapis.com" rel="dns-prefetch">
+                <link href="//fonts.gstatic.com" rel="dns-prefetch">
 
                 <!-- App stylesheet -->
                 <link id="app-css" rel="stylesheet" href="${assets['app.css']}">
@@ -57,6 +59,15 @@ export default function index({ head, rootHtml, config, buildManifest }) {
                 ga('create','${config.googleTrackingId}','auto');ga('send','pageview');
                 </script>
                 ` : ''}
+
+                <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js"></script>
+                <script>
+                  WebFont.load({
+                    google: {
+                      families: ['Rubik:300,400,500,700']
+                    }
+                  });
+                </script>
             </body>
         </html>
     `;


### PR DESCRIPTION
- uses web-font-loader (from cdn)
- only uses custom web-font after fonts have been loaded (FOUT instead of FOIT).
- "dns-prefetches" ajax.googleapis.com, fonts.googleapis.com and fonts.gstatic.com
- adds fallback typeface (it gets displayed while the web-fonts haven't been downloaded). I just picked an Helvetica font-stack which seemed similar to Rubik.